### PR TITLE
windows compatibility

### DIFF
--- a/build.js
+++ b/build.js
@@ -100,9 +100,9 @@ const rev = () => Promise.resolve().then(() => nodeRev({
   hash: true
 }))
 
-const clean = () => exec('rm -rf ./build && mkdir -p ./build/public')
-const polyfills = () => exec(`cp src/app/utils/polyfills.min.js build/public/`)
-const copy = () => exec(`cp -R src/app/static/. build/public/`)
+const clean = () => exec('rm -rf ./build && mkdirp ./build/public')
+const polyfills = () => exec(`cp ./src/app/utils/polyfills.min.js ./build/public/`)
+const copy = () => exec(`cp -R ./src/app/static/ ./build/public/`)
 
 const tasks = new Map()
 const run = (task) => {

--- a/build.js
+++ b/build.js
@@ -105,7 +105,7 @@ const rev = () => Promise.resolve().then(() => nodeRev({
 
 const clean = () => Promise.resolve(deleteFolder('./build'))
 const makePublicFolder = () => Promise.resolve(makeFolder('./build/public'))
-const polyfills = () => Promise.resolve(copyFolder(`src/app/utils/polyfills.min.js`, `build/public/`))
+const polyfills = () => Promise.resolve(copyFolder(`src/app/utils/polyfills.min.js`, `build/public/polyfills.min.js`))
 const copy = () => Promise.resolve(copyFolder(`src/app/static/`, `./build/public/`))
 
 const tasks = new Map()

--- a/build.js
+++ b/build.js
@@ -1,4 +1,4 @@
-const fs = require('fs')
+const fs = require('fs-extra')
 const rollup = require('rollup').rollup
 const _sass = require('node-sass')
 const buble = require('rollup-plugin-buble')
@@ -25,6 +25,9 @@ const promisify = (ctx, func = ctx) => (...args) => {
 }
 let clientCache, serverCache
 const writeFile = promisify(fs.writeFile)
+const deleteFolder = promisify(fs.remove)
+const makeFolder = promisify(fs.mkdirp)
+const copyFolder = promisify(fs.copy)
 const sass = promisify(_sass.render)
 const exec = promisify(_exec)
 
@@ -100,9 +103,10 @@ const rev = () => Promise.resolve().then(() => nodeRev({
   hash: true
 }))
 
-const clean = () => exec('rm -rf ./build && mkdirp ./build/public')
-const polyfills = () => exec(`cp ./src/app/utils/polyfills.min.js ./build/public/`)
-const copy = () => exec(`cp -R ./src/app/static/ ./build/public/`)
+const clean = () => Promise.resolve(deleteFolder('./build'))
+const makePublicFolder = () => Promise.resolve(makeFolder('./build/public'))
+const polyfills = () => Promise.resolve(copyFolder(`src/app/utils/polyfills.min.js`, `build/public/`))
+const copy = () => Promise.resolve(copyFolder(`src/app/static/`, `./build/public/`))
 
 const tasks = new Map()
 const run = (task) => {
@@ -120,9 +124,12 @@ tasks.set('clean', clean)
 tasks.set('rev', rev)
 tasks.set('sw', sw)
 tasks.set('server', server)
+tasks.set('makePublicFolder', makePublicFolder)
 tasks.set('build', () =>
   run('clean')
-  .then(() => Promise.all([run('client'), run('css'), run('polyfills'), run('copy')]))
+  .then(() => Promise.resolve(run('makePublicFolder')))
+  .then(() => Promise.resolve(run('css')))
+  .then(() => Promise.all([run('client'), run('polyfills'), run('copy')]))
   .then(() => run('rev'))
   .then(() => Promise.all([run('server'), run('sw')]))
 )

--- a/build.js
+++ b/build.js
@@ -27,7 +27,7 @@ let clientCache, serverCache
 const writeFile = promisify(fs.writeFile)
 const deleteFolder = promisify(fs.remove)
 const makeFolder = promisify(fs.mkdirp)
-const copyFolder = promisify(fs.copy)
+const copyFiles = promisify(fs.copy)
 const sass = promisify(_sass.render)
 const exec = promisify(_exec)
 
@@ -105,8 +105,8 @@ const rev = () => Promise.resolve().then(() => nodeRev({
 
 const clean = () => Promise.resolve(deleteFolder('./build'))
 const makePublicFolder = () => Promise.resolve(makeFolder('./build/public'))
-const polyfills = () => Promise.resolve(copyFolder(`src/app/utils/polyfills.min.js`, `build/public/polyfills.min.js`))
-const copy = () => Promise.resolve(copyFolder(`src/app/static/`, `./build/public/`))
+const polyfills = () => Promise.resolve(copyFiles(`src/app/utils/polyfills.min.js`, `build/public/polyfills.min.js`))
+const copy = () => Promise.resolve(copyFiles(`src/app/static/`, `./build/public/`))
 
 const tasks = new Map()
 const run = (task) => {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Super fast progressive web app",
   "scripts": {
-    "dev": "nodemon -e js,scss -w src -x && node build && node ./build/server.js",
+    "dev": "nodemon -e js,scss -w src -x \"node build && node ./build/server.js\"",
     "start": "node build && node ./build/server.js",
     "test": "standard"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Super fast progressive web app",
   "scripts": {
-    "dev": "nodemon -e js,scss -w src -x 'node build && node ./build/server.js'",
+    "dev": "nodemon -e js,scss -w src -x node build && node ./build/server.js",
     "start": "node build && node ./build/server.js",
     "test": "standard"
   },
@@ -12,6 +12,7 @@
     "cssnano": "3.10.0",
     "express": "4.14.1",
     "isomorphic-fetch": "2.2.1",
+    "mkdirp": "0.5.1",
     "node-rev": "2.0.0",
     "node-sass": "4.5.0",
     "nodemon": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Super fast progressive web app",
   "scripts": {
-    "dev": "nodemon -e js,scss -w src -x node build && node ./build/server.js",
+    "dev": "nodemon -e js,scss -w src -x && node build && node ./build/server.js",
     "start": "node build && node ./build/server.js",
     "test": "standard"
   },
@@ -12,7 +12,6 @@
     "cssnano": "3.10.0",
     "express": "4.14.1",
     "isomorphic-fetch": "2.2.1",
-    "mkdirp": "0.5.1",
     "node-rev": "2.0.0",
     "node-sass": "4.5.0",
     "nodemon": "1.11.0",
@@ -40,5 +39,8 @@
   },
   "engines": {
     "node": ">=6.9.1"
+  },
+  "devDependencies": {
+    "fs-extra": "^2.0.0"
   }
 }


### PR DESCRIPTION
Had to create a new pull request (sorry about this, you can delete the previous one). 

Basically as I see it to make the build process work on windows.

1) You have to remove the **'** character in the 
"dev": "nodemon -e js,scss -w src -x **'**node build && node ./build/server.js**'**"
"dev": "nodemon -e js,scss -w src -x **node build && node ./build/server.js**"

2) The mkdir doesn't work (even in the build.js file) so we need the mkdirp library unfortunately.
3) Making some folder paths more explicit.
For example **src/app/** => **./src/app/**

I'm not sure that these are compatible with a Mac/ Linux environment. But they were required for the windows env.
