### PR TITLE
Bind to PORT env variable if present

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,7 +1,7 @@
 import app from './app'
 require('source-map-support').install()
 
-const server = app.listen(3000, () => {
+const server = app.listen(process.env.PORT || 3000, () => {
   console.log(`[server] app on http://localhost:${server.address().port} - ${app.settings.env}`)
 })
 


### PR DESCRIPTION
It's a convention for PaaS services to provide a `PORT` environment variable to bind to on their platform. This checks for that and then falls back to a default of 3000. This makes this project easier to run on Heroku and other platforms, but should not affect anyone running it locally.