### PR TITLE
Add heroku-postbuild script hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "nodemon -e js,scss -w src -x \"node build && node ./build/server.js\"",
     "start": "node ./build/server.js",
     "build": "node build",
+    "heroku-postbuild": "node build",
     "test": "standard"
   },
   "dependencies": {


### PR DESCRIPTION
tl;dr - This will help anyone trying to run this on Heroku.

Longer version:

Using `npm run build` as a hook to bootstrap a server is an emergent convention that I'd like to support on Heroku, but it's difficult to introduce since adding it will likely break many existing applications. While I work on adding this as gently as possible, having this one additional script could be helpful to anyone trying to run this project on Heroku.

https://devcenter.heroku.com/articles/nodejs-support#heroku-specific-build-steps